### PR TITLE
feat: migrate to Istio HTTPRoute

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -10,4 +10,4 @@ jobs:
   release:
     uses: GersonRS/modern-gitops-stack/.github/workflows/modules-release-please.yaml@main
     secrets:
-      PAT: ${{ secrets.PAT }}
+      PROJECT_APP_PRIVATE_KEY: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}

--- a/charts/cp-schema-registry/templates/httproute.yaml
+++ b/charts/cp-schema-registry/templates/httproute.yaml
@@ -1,0 +1,19 @@
+{{- $httproute := (.Values.httproute | default dict) }}
+{{- if ($httproute.enabled | default false) }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: schema-registry
+spec:
+  parentRefs:
+    - name: {{ $httproute.gateway_name | default "istio-gateway" }}
+      namespace: {{ $httproute.gateway_namespace | default "istio-ingress" }}
+      sectionName: https
+  hostnames:
+    - {{ $httproute.host | quote }}
+  rules:
+    - backendRefs:
+        - name: schema-registry-cp-schema-registry
+          port: 8081
+{{- end }}

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,6 @@
 locals {
+  domain = format("schema-registry.%s", trimprefix("${var.subdomain}.${var.base_domain}", "."))
+
   helm_values = [{
     cp-helm-charts = {
       cp-kafka = {
@@ -25,6 +27,15 @@ locals {
       cp-control-center = {
         enabled = false
       }
+    }
+  }]
+
+  helm_values_httproute = [{
+    httproute = {
+      enabled           = true
+      host              = local.domain
+      gateway_name      = var.gateway_name
+      gateway_namespace = var.gateway_namespace
     }
   }]
 }

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "argocd_project" "this" {
 }
 
 data "utils_deep_merge_yaml" "values" {
-  input = [for i in concat(local.helm_values, var.helm_values) : yamlencode(i)]
+  input = [for i in concat(local.helm_values, local.helm_values_httproute, var.helm_values) : yamlencode(i)]
 }
 
 resource "argocd_application" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -89,3 +89,15 @@ variable "kafka_broker_name" {
   description = "kafka_broker_name"
   type        = string
 }
+
+variable "gateway_name" {
+  description = "Name of the Istio Gateway resource to attach the HTTPRoute to."
+  type        = string
+  default     = "istio-gateway"
+}
+
+variable "gateway_namespace" {
+  description = "Namespace of the Istio Gateway resource."
+  type        = string
+  default     = "istio-ingress"
+}


### PR DESCRIPTION
## Changes\n\n- Add `gateway_name` and `gateway_namespace` variables\n- Add `local.domain` and `helm_values_httproute` to `locals.tf`\n- Update `data.utils_deep_merge_yaml.values` to include httproute values\n- Create `charts/cp-schema-registry/templates/httproute.yaml`\n\n## Result\n\nSchema Registry REST API is now accessible at `https://schema-registry.{subdomain}.{base_domain}` via the Kubernetes Gateway API (Istio HTTPRoute), replacing the previous Traefik IngressRoute pattern.